### PR TITLE
fixing exclusion on 'new CPT' page

### DIFF
--- a/restrict-categories.php
+++ b/restrict-categories.php
@@ -31,12 +31,13 @@ class RestrictCategories{
 	private $cat_list = NULL;
 	
 	public function __construct(){
+		global $pagenow;
+		
 		// Make sure we are in the admin before proceeding.
 		if ( is_admin() ) {
-			$post_type = ( isset( $_GET['post_type'] ) ) ? $_GET['post_type'] : false;
-
+			
   			// If the page is the Posts screen, do our thing, otherwise chill
-			if ( $post_type == false || $post_type == 'post' )
+			if ( in_array( $pagenow, array( 'edit.php', 'post-new.php', 'post.php' ) ) )
 				add_action( 'admin_init', array( &$this, 'posts' ) );
 			
 			// Build options and settings pages.


### PR DESCRIPTION
Your plugin already work with custom post types, but only if you edit one. As you check for `$_GET['post_type']` before adding the filter to your `posts()` function the exclusion will not happen on a `post-new.php` page for the CPT, as it has this request param. Although editing a CPT entry does not have the `$_GET['post_type']` param set and therefore you are excluding the categories correctly.

With this little patch, the plugin will not check if a post_type param is set (I even don't know why you do that), but rather checks if the user is on a page to edit/create a post, page or CPT.

As you don't have you latest development branch from SVN on Github (trunk), I filed this pull request against your latest version. But you should be able to apply the patch/diff on your current SVN develpoment branch. If you need help with that, just let me know.
