### PR TITLE
update register_settings parameters

### DIFF
--- a/restrict-categories.php
+++ b/restrict-categories.php
@@ -65,8 +65,8 @@ class RestrictCategories{
 	 * @uses register_setting() Register a setting in the database
 	 */
 	public function init() {
-		register_setting( 'RestrictCats_options_group', 'RestrictCats_options', array( &$this, 'options_sanitize' ) );
-		register_setting( 'RestrictCats_user_options_group', 'RestrictCats_user_options', array( &$this, 'options_sanitize' ) );
+		register_setting( 'RestrictCats_options_group', 'RestrictCats_options', array( 'sanitize_callback' => &$this->options_sanitize ) );
+		register_setting( 'RestrictCats_user_options_group', 'RestrictCats_user_options', array( 'sanitize_callback' => &$this->options_sanitize ) );
 				
 		// Set the options to a variable
 		add_option( 'RestrictCats_options' );


### PR DESCRIPTION
As of Wordpress 4.7, [register_settings parameters have changed](https://make.wordpress.org/core/2016/10/26/registering-your-settings-in-wordpress-4-7/). Updated third parameter to new format. So far, testing under WP 4.8.2 is successful.